### PR TITLE
Added instructions for AZ-Touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ dtparam=rotate=0
 fbcon=map:10 fbcon=font:VGA8x8 logo.nologo
 ```
 
+#### for AZ-Touch Pi0
+
+follow the above instructions for the ili9341 and then replace `/boot/overlays/rpi-display.dtbo` with the copy from https://github.com/HWHardsoft/AZ-Touch-Pi0-Weather.
 
 #### for Pimoroni Hyperpixel4
 


### PR DESCRIPTION
Thanks @LoveBootCaptain for a great software product. I decided to install from scratch on an AZ-Touch Pi0 display and I discovered that despite it being an ili9341 I needed a different rpi-display overlay. I've added a description of this to README.md.